### PR TITLE
feature: add clear street brokerage integration

### DIFF
--- a/Common/Brokerages/BrokerageName.cs
+++ b/Common/Brokerages/BrokerageName.cs
@@ -212,6 +212,11 @@ namespace QuantConnect.Brokerages
         /// <summary>
         /// Transaction and submit/execution rules will use bloomberg fix models
         /// </summary>
-        BloombergFix
+        BloombergFix,
+
+        /// <summary>
+        /// Transaction and submit/execution rules will use Clear Street models
+        /// </summary>
+        ClearStreet
     }
 }

--- a/Common/Brokerages/ClearStreetBrokerageModel.cs
+++ b/Common/Brokerages/ClearStreetBrokerageModel.cs
@@ -14,7 +14,6 @@
  *
 */
 
-using QuantConnect.Util;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
 using System.Collections.Generic;
@@ -27,24 +26,14 @@ namespace QuantConnect.Brokerages
     public class ClearStreetBrokerageModel : DefaultBrokerageModel
     {
         /// <summary>
-        /// The default markets for Clear Street.
-        /// </summary>
-        public new static readonly IReadOnlyDictionary<SecurityType, string> DefaultMarketMap = new Dictionary<SecurityType, string>
-        {
-            { SecurityType.Equity, Market.USA },
-            { SecurityType.Option, Market.USA },
-            { SecurityType.Index, Market.USA }
-        }.ToReadOnlyDictionary();
-
-        /// <summary>
         /// The security types Clear Street accepts orders for.
-        /// <see cref="SecurityType.Index"/> is missing on purpose, see <see cref="CanSubmitOrder"/>.
         /// </summary>
         private readonly HashSet<SecurityType> _supportSecurityTypes = new(
             new[]
             {
                 SecurityType.Equity,
-                SecurityType.Option
+                SecurityType.Option,
+                SecurityType.IndexOption
             });
 
         /// <summary>
@@ -59,14 +48,6 @@ namespace QuantConnect.Brokerages
                 OrderType.StopLimit,
                 OrderType.TrailingStop
             });
-
-        /// <summary>
-        /// Gets a map of the default markets to be used for each security type
-        /// </summary>
-        public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets
-        {
-            get { return DefaultMarketMap; }
-        }
 
         /// <summary>
         /// Constructor for Clear Street brokerage model
@@ -88,14 +69,6 @@ namespace QuantConnect.Brokerages
         {
             message = default;
 
-            // Clear Street serves index quotes, but it holds no index position and takes no index order.
-            if (security.Type == SecurityType.Index)
-            {
-                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
-                    Messages.ClearStreetBrokerageModel.IndexIsNotTradable(security));
-                return false;
-            }
-
             if (!_supportSecurityTypes.Contains(security.Type))
             {
                 message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
@@ -110,8 +83,6 @@ namespace QuantConnect.Brokerages
                 return false;
             }
 
-            // Clear Street works out the open or close effect of an order itself, so an order that
-            // crosses a zero position is sent as one order and is not split here.
             return base.CanSubmitOrder(security, order, out message);
         }
     }

--- a/Common/Brokerages/ClearStreetBrokerageModel.cs
+++ b/Common/Brokerages/ClearStreetBrokerageModel.cs
@@ -1,0 +1,118 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+using QuantConnect.Util;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using System.Collections.Generic;
+
+namespace QuantConnect.Brokerages
+{
+    /// <summary>
+    /// Represents a brokerage model specific to Clear Street.
+    /// </summary>
+    public class ClearStreetBrokerageModel : DefaultBrokerageModel
+    {
+        /// <summary>
+        /// The default markets for Clear Street.
+        /// </summary>
+        public new static readonly IReadOnlyDictionary<SecurityType, string> DefaultMarketMap = new Dictionary<SecurityType, string>
+        {
+            { SecurityType.Equity, Market.USA },
+            { SecurityType.Option, Market.USA },
+            { SecurityType.Index, Market.USA }
+        }.ToReadOnlyDictionary();
+
+        /// <summary>
+        /// The security types Clear Street accepts orders for.
+        /// <see cref="SecurityType.Index"/> is missing on purpose, see <see cref="CanSubmitOrder"/>.
+        /// </summary>
+        private readonly HashSet<SecurityType> _supportSecurityTypes = new(
+            new[]
+            {
+                SecurityType.Equity,
+                SecurityType.Option
+            });
+
+        /// <summary>
+        /// The order types supported by the <see cref="CanSubmitOrder"/> operation in Clear Street.
+        /// </summary>
+        private readonly HashSet<OrderType> _supportOrderTypes = new(
+            new[]
+            {
+                OrderType.Market,
+                OrderType.Limit,
+                OrderType.StopMarket,
+                OrderType.StopLimit,
+                OrderType.TrailingStop
+            });
+
+        /// <summary>
+        /// Gets a map of the default markets to be used for each security type
+        /// </summary>
+        public override IReadOnlyDictionary<SecurityType, string> DefaultMarkets
+        {
+            get { return DefaultMarketMap; }
+        }
+
+        /// <summary>
+        /// Constructor for Clear Street brokerage model
+        /// </summary>
+        /// <param name="accountType">Cash or Margin</param>
+        public ClearStreetBrokerageModel(AccountType accountType = AccountType.Margin)
+            : base(accountType)
+        {
+        }
+
+        /// <summary>
+        /// Returns true if the brokerage could accept this order. This takes into account order type, security type.
+        /// </summary>
+        /// <param name="security">The security of the order</param>
+        /// <param name="order">The order to be processed</param>
+        /// <param name="message">If this function returns false, a brokerage message detailing why the order may not be submitted</param>
+        /// <returns>True if the brokerage could process the order, false otherwise</returns>
+        public override bool CanSubmitOrder(Security security, Order order, out BrokerageMessageEvent message)
+        {
+            message = default;
+
+            // Clear Street serves index quotes, but it holds no index position and takes no index order.
+            if (security.Type == SecurityType.Index)
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.ClearStreetBrokerageModel.IndexIsNotTradable(security));
+                return false;
+            }
+
+            if (!_supportSecurityTypes.Contains(security.Type))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.DefaultBrokerageModel.UnsupportedSecurityType(this, security));
+                return false;
+            }
+
+            if (!_supportOrderTypes.Contains(order.Type))
+            {
+                message = new BrokerageMessageEvent(BrokerageMessageType.Warning, "NotSupported",
+                    Messages.DefaultBrokerageModel.UnsupportedOrderType(this, order, _supportOrderTypes));
+                return false;
+            }
+
+            // Clear Street works out the open or close effect of an order itself, so an order that
+            // crosses a zero position is sent as one order and is not split here.
+            return base.CanSubmitOrder(security, order, out message);
+        }
+    }
+}

--- a/Common/Brokerages/IBrokerageModel.cs
+++ b/Common/Brokerages/IBrokerageModel.cs
@@ -302,6 +302,9 @@ namespace QuantConnect.Brokerages
                 case BrokerageName.BloombergFix:
                     return new BloombergFixBrokerageModel(accountType);
 
+                case BrokerageName.ClearStreet:
+                    return new ClearStreetBrokerageModel(accountType);
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(brokerage), brokerage, null);
             }
@@ -413,6 +416,9 @@ namespace QuantConnect.Brokerages
 
                 case BloombergFixBrokerageModel _:
                     return BrokerageName.BloombergFix;
+
+                case ClearStreetBrokerageModel:
+                    return BrokerageName.ClearStreet;
 
                 case DefaultBrokerageModel _:
                     return BrokerageName.Default;

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
  * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
  *
@@ -640,21 +640,6 @@ namespace QuantConnect
             public static string ExtendedMarketOrderMustBeLimit(Orders.Order order)
             {
                 return Invariant($"Orders for extended market must be of type '{nameof(OrderType.Limit)}' and with 'DAY' time-in-force, but {order.Type} was specified.");
-            }
-        }
-
-        /// <summary>
-        /// Provides user-facing messages for the <see cref="Brokerages.ClearStreetBrokerageModel"/> class and its consumers or related classes
-        /// </summary>
-        public static class ClearStreetBrokerageModel
-        {
-            /// <summary>
-            /// Returns a message explaining that an index can be subscribed to, but not traded.
-            /// </summary>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static string IndexIsNotTradable(Securities.Security security)
-            {
-                return Invariant($"Clear Street sends {security.Type} data, but it takes no {security.Type} orders. {security.Symbol.Value} cannot be traded.");
             }
         }
 

--- a/Common/Messages/Messages.Brokerages.cs
+++ b/Common/Messages/Messages.Brokerages.cs
@@ -644,6 +644,21 @@ namespace QuantConnect
         }
 
         /// <summary>
+        /// Provides user-facing messages for the <see cref="Brokerages.ClearStreetBrokerageModel"/> class and its consumers or related classes
+        /// </summary>
+        public static class ClearStreetBrokerageModel
+        {
+            /// <summary>
+            /// Returns a message explaining that an index can be subscribed to, but not traded.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string IndexIsNotTradable(Securities.Security security)
+            {
+                return Invariant($"Clear Street sends {security.Type} data, but it takes no {security.Type} orders. {security.Symbol.Value} cannot be traded.");
+            }
+        }
+
+        /// <summary>
         /// Provides user-facing messages for the <see cref="Brokerages.RBIBrokerageModel"/> class and its consumers or related classes
         /// </summary>
         public static class RBIBrokerageModel

--- a/Common/Orders/ClearStreetOrderProperties.cs
+++ b/Common/Orders/ClearStreetOrderProperties.cs
@@ -14,6 +14,8 @@
  *
 */
 
+using QuantConnect.Interfaces;
+
 namespace QuantConnect.Orders
 {
     /// <summary>
@@ -29,5 +31,13 @@ namespace QuantConnect.Orders
         /// Clear Street reads this as the <c>extended_hours</c> field of the order request.
         /// </remarks>
         public bool OutsideRegularTradingHours { get; set; }
+
+        /// <summary>
+        /// Returns a new instance clone of this object
+        /// </summary>
+        public override IOrderProperties Clone()
+        {
+            return (ClearStreetOrderProperties)MemberwiseClone();
+        }
     }
 }

--- a/Common/Orders/ClearStreetOrderProperties.cs
+++ b/Common/Orders/ClearStreetOrderProperties.cs
@@ -1,0 +1,33 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+namespace QuantConnect.Orders
+{
+    /// <summary>
+    /// Represents the properties of an order in Clear Street.
+    /// </summary>
+    public class ClearStreetOrderProperties : OrderProperties
+    {
+        /// <summary>
+        /// If set to <c>true</c>, allows the order to trigger or fill outside of regular trading hours
+        /// (the extended session).
+        /// </summary>
+        /// <remarks>
+        /// Clear Street reads this as the <c>extended_hours</c> field of the order request.
+        /// </remarks>
+        public bool OutsideRegularTradingHours { get; set; }
+    }
+}

--- a/Launcher/config.json
+++ b/Launcher/config.json
@@ -289,6 +289,12 @@
   // Users can have multiple different accounts
   "public-account-number": "",
 
+  // Clear Street configuration
+  "clearstreet-api-url": "https://api.clearstreet.com",
+  "clearstreet-access-token": "",
+  // Users can have more than one account
+  "clearstreet-account-id": "",
+
   // Exante trading configuration
   // client-id, application-id, shared-key are required to access Exante REST API
   // Exante generates them at https://exante.eu/clientsarea/dashboard/ after adding an application
@@ -775,6 +781,22 @@
 
       // real brokerage implementations require the BrokerageTransactionHandler
       "live-mode-brokerage": "BloombergFixBrokerage",
+      "data-queue-handler": [ "QuantConnect.Lean.Engine.DataFeeds.Queues.LiveDataQueue" ],
+      "history-provider": [ "SubscriptionDataReaderHistoryProvider" ],
+      "setup-handler": "QuantConnect.Lean.Engine.Setup.BrokerageSetupHandler",
+      "result-handler": "QuantConnect.Lean.Engine.Results.LiveTradingResultHandler",
+      "data-feed-handler": "QuantConnect.Lean.Engine.DataFeeds.LiveTradingDataFeed",
+      "real-time-handler": "QuantConnect.Lean.Engine.RealTime.LiveTradingRealTimeHandler",
+      "transaction-handler": "QuantConnect.Lean.Engine.TransactionHandlers.BrokerageTransactionHandler"
+    },
+
+    // defines the 'live-clearstreet' environment
+    "live-clearstreet": {
+      "live-mode": true,
+
+      // real brokerage implementations require the BrokerageTransactionHandler
+      "live-mode-brokerage": "ClearStreetBrokerage",
+      // Clear Street serves no market data and no history, so Lean uses its own data feed
       "data-queue-handler": [ "QuantConnect.Lean.Engine.DataFeeds.Queues.LiveDataQueue" ],
       "history-provider": [ "SubscriptionDataReaderHistoryProvider" ],
       "setup-handler": "QuantConnect.Lean.Engine.Setup.BrokerageSetupHandler",

--- a/Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs
@@ -1,0 +1,202 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using System;
+using NUnit.Framework;
+using QuantConnect.Orders;
+using QuantConnect.Brokerages;
+using QuantConnect.Securities;
+using QuantConnect.Tests.Brokerages;
+
+namespace QuantConnect.Tests.Common.Brokerages
+{
+    [TestFixture]
+    public class ClearStreetBrokerageModelTests
+    {
+        private readonly ClearStreetBrokerageModel _brokerageModel = new();
+
+        // Equity and Option accept every order type Clear Street knows.
+        [TestCase(SecurityType.Equity, OrderType.Market)]
+        [TestCase(SecurityType.Equity, OrderType.Limit)]
+        [TestCase(SecurityType.Equity, OrderType.StopMarket)]
+        [TestCase(SecurityType.Equity, OrderType.StopLimit)]
+        [TestCase(SecurityType.Equity, OrderType.TrailingStop)]
+        [TestCase(SecurityType.Option, OrderType.Market)]
+        [TestCase(SecurityType.Option, OrderType.Limit)]
+        [TestCase(SecurityType.Option, OrderType.StopMarket)]
+        [TestCase(SecurityType.Option, OrderType.StopLimit)]
+        [TestCase(SecurityType.Option, OrderType.TrailingStop)]
+        public void CanSubmitOrderValidSecurityAndOrderTypeReturnsTrue(SecurityType securityType, OrderType orderType)
+        {
+            var security = GetSecurityForType(securityType);
+            var order = CreateOrder(orderType, security.Symbol);
+
+            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
+
+            Assert.That(canSubmit, Is.True);
+            Assert.That(message, Is.Null);
+        }
+
+        // An index can be subscribed to, but Clear Street takes no index order.
+        [TestCase(OrderType.Market)]
+        [TestCase(OrderType.Limit)]
+        [TestCase(OrderType.StopMarket)]
+        [TestCase(OrderType.StopLimit)]
+        [TestCase(OrderType.TrailingStop)]
+        public void CanSubmitOrderIndexReturnsFalse(OrderType orderType)
+        {
+            var security = GetSecurityForType(SecurityType.Index);
+            var order = CreateOrder(orderType, security.Symbol);
+
+            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
+
+            Assert.That(canSubmit, Is.False);
+            Assert.That(message, Is.Not.Null);
+            Assert.That(message.Message, Does.Contain(nameof(SecurityType.Index)));
+        }
+
+        [TestCase(SecurityType.Forex)]
+        [TestCase(SecurityType.Cfd)]
+        [TestCase(SecurityType.Future)]
+        [TestCase(SecurityType.FutureOption)]
+        [TestCase(SecurityType.IndexOption)]
+        [TestCase(SecurityType.Crypto)]
+        public void CanSubmitOrderUnsupportedSecurityTypeReturnsFalse(SecurityType securityType)
+        {
+            var security = GetSecurityForType(securityType);
+            var order = new MarketOrder(security.Symbol, 1m, DateTime.UtcNow);
+
+            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
+
+            Assert.That(canSubmit, Is.False);
+            Assert.That(message, Is.Not.Null);
+            Assert.That(message.Message, Does.Contain(nameof(ClearStreetBrokerageModel)));
+        }
+
+        [TestCase(SecurityType.Equity, OrderType.MarketOnClose)]
+        [TestCase(SecurityType.Equity, OrderType.MarketOnOpen)]
+        [TestCase(SecurityType.Equity, OrderType.LimitIfTouched)]
+        [TestCase(SecurityType.Equity, OrderType.ComboMarket)]
+        [TestCase(SecurityType.Equity, OrderType.ComboLimit)]
+        [TestCase(SecurityType.Option, OrderType.MarketOnClose)]
+        [TestCase(SecurityType.Option, OrderType.ComboLimit)]
+        public void CanSubmitOrderUnsupportedOrderTypeReturnsFalse(SecurityType securityType, OrderType orderType)
+        {
+            var security = GetSecurityForType(securityType);
+            var order = CreateOrder(orderType, security.Symbol);
+
+            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
+
+            Assert.That(canSubmit, Is.False);
+            Assert.That(message, Is.Not.Null);
+            Assert.That(message.Message, Does.Contain(orderType.ToString()));
+        }
+
+        [TestCase(SecurityType.Equity)]
+        [TestCase(SecurityType.Option)]
+        public void CanUpdateOrderReturnsTrue(SecurityType securityType)
+        {
+            var security = GetSecurityForType(securityType);
+            var order = new LimitOrder(security.Symbol, 1m, 100m, DateTime.UtcNow);
+            var request = new UpdateOrderRequest(DateTime.UtcNow, order.Id, new UpdateOrderFields { LimitPrice = 99m });
+
+            var canUpdate = _brokerageModel.CanUpdateOrder(security, order, request, out var message);
+
+            Assert.That(canUpdate, Is.True);
+            Assert.That(message, Is.Null);
+        }
+
+        [TestCase(SecurityType.Equity)]
+        [TestCase(SecurityType.Option)]
+        [TestCase(SecurityType.Index)]
+        public void DefaultMarketsReturnsUsa(SecurityType securityType)
+        {
+            Assert.That(_brokerageModel.DefaultMarkets[securityType], Is.EqualTo(Market.USA));
+        }
+
+        [Test]
+        public void DefaultMarketsHoldsOnlyTheSecurityTypesClearStreetServes()
+        {
+            Assert.That(_brokerageModel.DefaultMarkets.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void CreateReturnsClearStreetBrokerageModel()
+        {
+            var model = BrokerageModel.Create(new OrderProvider(), BrokerageName.ClearStreet, AccountType.Margin);
+
+            Assert.That(model, Is.InstanceOf<ClearStreetBrokerageModel>());
+            Assert.That(BrokerageModel.GetBrokerageName(model), Is.EqualTo(BrokerageName.ClearStreet));
+        }
+
+        private static Security GetSecurityForType(SecurityType securityType)
+        {
+            switch (securityType)
+            {
+                case SecurityType.Future:
+                    return TestsHelpers.GetSecurity(securityType: SecurityType.Future,
+                        symbol: Futures.Indices.SP500EMini, market: Market.CME);
+                case SecurityType.FutureOption:
+                    return TestsHelpers.GetSecurity(securityType: SecurityType.FutureOption,
+                        symbol: Futures.Indices.SP500EMini, market: Market.CME);
+                case SecurityType.Crypto:
+                    return TestsHelpers.GetSecurity(securityType: SecurityType.Crypto,
+                        symbol: "BTCUSD", market: Market.Coinbase);
+                case SecurityType.Forex:
+                case SecurityType.Cfd:
+                    return TestsHelpers.GetSecurity(securityType: securityType,
+                        symbol: "EURUSD", market: Market.Oanda);
+                case SecurityType.IndexOption:
+                    return TestsHelpers.GetSecurity(securityType: SecurityType.IndexOption,
+                        symbol: "SPX", market: Market.CBOE);
+                case SecurityType.Index:
+                    return TestsHelpers.GetSecurity(securityType: SecurityType.Index,
+                        symbol: "SPX", market: Market.USA);
+                default:
+                    return TestsHelpers.GetSecurity(securityType: securityType,
+                        symbol: "AAPL", market: Market.USA);
+            }
+        }
+
+        private static Order CreateOrder(OrderType orderType, Symbol symbol)
+        {
+            switch (orderType)
+            {
+                case OrderType.Market:
+                    return new MarketOrder(symbol, 1m, DateTime.UtcNow);
+                case OrderType.Limit:
+                    return new LimitOrder(symbol, 1m, 100m, DateTime.UtcNow);
+                case OrderType.StopMarket:
+                    return new StopMarketOrder(symbol, 1m, 100m, DateTime.UtcNow);
+                case OrderType.StopLimit:
+                    return new StopLimitOrder(symbol, 1m, 105m, 100m, DateTime.UtcNow);
+                case OrderType.TrailingStop:
+                    return new TrailingStopOrder(symbol, 1m, 100m, 1m, false, DateTime.UtcNow);
+                case OrderType.MarketOnClose:
+                    return new MarketOnCloseOrder(symbol, 1m, DateTime.UtcNow);
+                case OrderType.MarketOnOpen:
+                    return new MarketOnOpenOrder(symbol, 1m, DateTime.UtcNow);
+                case OrderType.LimitIfTouched:
+                    return new LimitIfTouchedOrder(symbol, 1m, 105m, 100m, DateTime.UtcNow);
+                case OrderType.ComboMarket:
+                    return new ComboMarketOrder(symbol, 1m, DateTime.UtcNow, new GroupOrderManager(1, 1, 1m));
+                case OrderType.ComboLimit:
+                    return new ComboLimitOrder(symbol, 1m, 100m, DateTime.UtcNow, new GroupOrderManager(1, 1, 1m));
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(orderType), orderType, null);
+            }
+        }
+    }
+}

--- a/Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs
+++ b/Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs
@@ -27,7 +27,7 @@ namespace QuantConnect.Tests.Common.Brokerages
     {
         private readonly ClearStreetBrokerageModel _brokerageModel = new();
 
-        // Equity and Option accept every order type Clear Street knows.
+        // Equity, Option and IndexOption accept every order type Clear Street knows.
         [TestCase(SecurityType.Equity, OrderType.Market)]
         [TestCase(SecurityType.Equity, OrderType.Limit)]
         [TestCase(SecurityType.Equity, OrderType.StopMarket)]
@@ -38,6 +38,11 @@ namespace QuantConnect.Tests.Common.Brokerages
         [TestCase(SecurityType.Option, OrderType.StopMarket)]
         [TestCase(SecurityType.Option, OrderType.StopLimit)]
         [TestCase(SecurityType.Option, OrderType.TrailingStop)]
+        [TestCase(SecurityType.IndexOption, OrderType.Market)]
+        [TestCase(SecurityType.IndexOption, OrderType.Limit)]
+        [TestCase(SecurityType.IndexOption, OrderType.StopMarket)]
+        [TestCase(SecurityType.IndexOption, OrderType.StopLimit)]
+        [TestCase(SecurityType.IndexOption, OrderType.TrailingStop)]
         public void CanSubmitOrderValidSecurityAndOrderTypeReturnsTrue(SecurityType securityType, OrderType orderType)
         {
             var security = GetSecurityForType(securityType);
@@ -49,29 +54,11 @@ namespace QuantConnect.Tests.Common.Brokerages
             Assert.That(message, Is.Null);
         }
 
-        // An index can be subscribed to, but Clear Street takes no index order.
-        [TestCase(OrderType.Market)]
-        [TestCase(OrderType.Limit)]
-        [TestCase(OrderType.StopMarket)]
-        [TestCase(OrderType.StopLimit)]
-        [TestCase(OrderType.TrailingStop)]
-        public void CanSubmitOrderIndexReturnsFalse(OrderType orderType)
-        {
-            var security = GetSecurityForType(SecurityType.Index);
-            var order = CreateOrder(orderType, security.Symbol);
-
-            var canSubmit = _brokerageModel.CanSubmitOrder(security, order, out var message);
-
-            Assert.That(canSubmit, Is.False);
-            Assert.That(message, Is.Not.Null);
-            Assert.That(message.Message, Does.Contain(nameof(SecurityType.Index)));
-        }
-
         [TestCase(SecurityType.Forex)]
         [TestCase(SecurityType.Cfd)]
         [TestCase(SecurityType.Future)]
         [TestCase(SecurityType.FutureOption)]
-        [TestCase(SecurityType.IndexOption)]
+        [TestCase(SecurityType.Index)]
         [TestCase(SecurityType.Crypto)]
         public void CanSubmitOrderUnsupportedSecurityTypeReturnsFalse(SecurityType securityType)
         {
@@ -92,6 +79,8 @@ namespace QuantConnect.Tests.Common.Brokerages
         [TestCase(SecurityType.Equity, OrderType.ComboLimit)]
         [TestCase(SecurityType.Option, OrderType.MarketOnClose)]
         [TestCase(SecurityType.Option, OrderType.ComboLimit)]
+        [TestCase(SecurityType.IndexOption, OrderType.MarketOnOpen)]
+        [TestCase(SecurityType.IndexOption, OrderType.ComboMarket)]
         public void CanSubmitOrderUnsupportedOrderTypeReturnsFalse(SecurityType securityType, OrderType orderType)
         {
             var security = GetSecurityForType(securityType);
@@ -106,6 +95,7 @@ namespace QuantConnect.Tests.Common.Brokerages
 
         [TestCase(SecurityType.Equity)]
         [TestCase(SecurityType.Option)]
+        [TestCase(SecurityType.IndexOption)]
         public void CanUpdateOrderReturnsTrue(SecurityType securityType)
         {
             var security = GetSecurityForType(securityType);
@@ -116,20 +106,6 @@ namespace QuantConnect.Tests.Common.Brokerages
 
             Assert.That(canUpdate, Is.True);
             Assert.That(message, Is.Null);
-        }
-
-        [TestCase(SecurityType.Equity)]
-        [TestCase(SecurityType.Option)]
-        [TestCase(SecurityType.Index)]
-        public void DefaultMarketsReturnsUsa(SecurityType securityType)
-        {
-            Assert.That(_brokerageModel.DefaultMarkets[securityType], Is.EqualTo(Market.USA));
-        }
-
-        [Test]
-        public void DefaultMarketsHoldsOnlyTheSecurityTypesClearStreetServes()
-        {
-            Assert.That(_brokerageModel.DefaultMarkets.Count, Is.EqualTo(3));
         }
 
         [Test]

--- a/Tests/Common/Orders/ClearStreetOrderPropertiesTests.cs
+++ b/Tests/Common/Orders/ClearStreetOrderPropertiesTests.cs
@@ -1,0 +1,54 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using NUnit.Framework;
+using QuantConnect.Orders;
+
+namespace QuantConnect.Tests.Common.Orders
+{
+    [TestFixture]
+    public class ClearStreetOrderPropertiesTests
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void OutsideRegularTradingHoursCanBeSetAndRetrieved(bool outsideRegularTradingHours)
+        {
+            var properties = new ClearStreetOrderProperties { OutsideRegularTradingHours = outsideRegularTradingHours };
+
+            Assert.That(properties.OutsideRegularTradingHours, Is.EqualTo(outsideRegularTradingHours));
+        }
+
+        [Test]
+        public void CloneReturnsNewInstanceWithSameValues()
+        {
+            var properties = new ClearStreetOrderProperties
+            {
+                OutsideRegularTradingHours = true,
+                TimeInForce = TimeInForce.Day
+            };
+
+            var clone = properties.Clone() as ClearStreetOrderProperties;
+
+            Assert.That(clone, Is.Not.Null);
+            Assert.That(clone, Is.Not.SameAs(properties));
+            Assert.That(clone.OutsideRegularTradingHours, Is.True);
+            Assert.That(clone.TimeInForce, Is.EqualTo(properties.TimeInForce));
+
+            clone.OutsideRegularTradingHours = false;
+
+            Assert.That(properties.OutsideRegularTradingHours, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Registers Clear Street in Lean core: the `BrokerageName.ClearStreet` value, a `ClearStreetBrokerageModel`, the factory wiring, `ClearStreetOrderProperties`, and the launcher configuration. The plugin itself lives in [Lean.Brokerages.ClearStreet](https://github.com/Romazes/Lean.Brokerages.ClearStreet).

The model accepts `Equity`, `Option` and `IndexOption`, and five order types: Market, Limit, StopMarket, StopLimit and TrailingStop. Anything else is refused with the standard Lean message, so an algorithm learns the limit at submit time instead of hitting an exception inside the plugin:

```csharp
// Equity, Option and IndexOption are accepted
brokerageModel.CanSubmitOrder(equitySecurity, marketOrder, out _);       // true
brokerageModel.CanSubmitOrder(optionSecurity, limitOrder, out _);        // true
brokerageModel.CanSubmitOrder(indexOptionSecurity, stopLimitOrder, out _); // true

// Other security types are refused
brokerageModel.CanSubmitOrder(indexSecurity, marketOrder, out var message);   // false
// message: "The ClearStreetBrokerageModel does not support Index security type."

// Unsupported order types are refused the same way
brokerageModel.CanSubmitOrder(equitySecurity, marketOnOpenOrder, out message);   // false
// message: "The ClearStreetBrokerageModel does not support MarketOnOpen order type.
//           Only supports [Market,Limit,StopMarket,StopLimit,TrailingStop]"
```

`ClearStreetOrderProperties` carries one extra flag. Clear Street reads it as the `extended_hours` field of the order request:

```csharp
// let the order trigger or fill in the extended session
order.OrderProperties = new ClearStreetOrderProperties { OutsideRegularTradingHours = true };
```

The model keeps the default market map from `DefaultBrokerageModel`, so it adds no map of its own.

#### Related PR(s)

N/A

#### Related Issue

N/A

#### Motivation and Context

Lean cannot run the Clear Street plugin until the brokerage name and its model exist in core. Without the model, order and security type limits are unchecked, so an order Clear Street cannot accept is only refused later by the plugin, as an exception during conversion instead of a clear message to the algorithm.

#### Requires Documentation Change

No.

#### How Has This Been Tested?

- `Tests/Common/Brokerages/ClearStreetBrokerageModelTests.cs` — 34 cases. They cover the three accepted security types against all five supported order types, the refused security types (`Forex`, `Cfd`, `Future`, `FutureOption`, `Index`, `Crypto`), the refused order types (`MarketOnClose`, `MarketOnOpen`, `LimitIfTouched`, `ComboMarket`, `ComboLimit`), `CanUpdateOrder`, and the round trip `BrokerageName.ClearStreet` to `ClearStreetBrokerageModel` and back.
- `Tests/Common/Orders/ClearStreetOrderPropertiesTests.cs` — 3 cases. They check that `OutsideRegularTradingHours` can be set and read, and that `Clone()` returns a separate object holding the same flag and time in force.
- `Launcher/config.json` was parsed after the change to check it is still valid JSON.
- The supported types come from the live Clear Street API, not only from its specification. The option symbol format was read from production responses while building the plugin.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
